### PR TITLE
Fix Yeedi API endpoints to use brand hosts

### DIFF
--- a/custom_components/yeedi_c12_cloud/helpers.py
+++ b/custom_components/yeedi_c12_cloud/helpers.py
@@ -1,0 +1,48 @@
+"""Helpers for configuring Yeedi-specific API endpoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Optional
+
+from aiohttp import ClientSession
+
+from deebot_client.authentication import RestConfiguration, create_rest_config
+
+
+@dataclass(frozen=True, slots=True)
+class YeediApiConfig:
+    """Container for the API configuration pieces we care about."""
+
+    rest: RestConfiguration
+    mqtt_override: Optional[str] = None
+
+
+def create_yeedi_api_config(
+    session: ClientSession,
+    *,
+    device_id: str,
+    alpha_2_country: str,
+) -> YeediApiConfig:
+    """Return a Yeedi-specific REST configuration and MQTT override (if any).
+
+    We leverage :func:`deebot_client.authentication.create_rest_config` to build
+    a base `RestConfiguration` and immediately swap the login URLs to point at
+    the Yeedi-branded hosts.  Yeedi's cloud still routes MQTT traffic through
+    the Ecovacs-operated ``mq*.ecouser.net`` brokers, so no override is required
+    for MQTT today; keeping the default documents that behaviour for future
+    maintainers.
+    """
+
+    base = create_rest_config(
+        session,
+        device_id=device_id,
+        alpha_2_country=alpha_2_country,
+    )
+    country_slug = base.country.lower()
+    tld = "cn" if alpha_2_country.upper() == "CN" else "com"
+    login_url = f"https://gl-{country_slug}-api.yeedi.{tld}"
+    auth_code_url = f"https://gl-{country_slug}-openapi.yeedi.{tld}"
+
+    rest = replace(base, login_url=login_url, auth_code_url=auth_code_url)
+    return YeediApiConfig(rest=rest, mqtt_override=None)


### PR DESCRIPTION
## Summary
- add a Yeedi helper that swaps the REST login/auth endpoints to the Yeedi domains
- use the shared helper in the config flow and vacuum runtime so both sessions hit the same URLs
- document that Yeedi accounts still connect via the Ecovacs MQTT broker, so no override is necessary today

## Testing
- python -m compileall custom_components/yeedi_c12_cloud
- Manual Yeedi account verification (not run in CI)


------
https://chatgpt.com/codex/tasks/task_e_68d9f2280dd483259e9b5007a8925015