### PR TITLE
Add login smoke test scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .aider*
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -60,6 +60,25 @@ target:
 - Enable debug logs (see CONTRIBUTING.md) and check Developer Tools → Logs.
 - Common issues: invalid credentials, wrong country code, or no MQTT-capable devices on the account.
 
+### Login smoke tests
+Need to quickly validate that the cloud login still works? Use the helper scripts in
+`scripts/` with your Yeedi credentials (they are never stored):
+
+```bash
+export YEEDI_ACCOUNT="name@example.com"
+export YEEDI_PASSWORD="super-secret"
+# Optional if you are not in the US
+export YEEDI_COUNTRY="GB"
+
+python scripts/login_smoke_success.py
+
+# To confirm that bad credentials are rejected
+python scripts/login_smoke_failure.py
+```
+
+The scripts exit with a non-zero status on unexpected results so they can be wired into
+CI or run ad-hoc after dependency updates.
+
 For contributor guidelines, coding standards, and test flow, see AGENTS.md and CONTRIBUTING.md.
 
 ## Maps Roadmap

--- a/scripts/login_smoke_failure.py
+++ b/scripts/login_smoke_failure.py
@@ -1,0 +1,31 @@
+"""Negative smoke-test script ensuring invalid logins are rejected."""
+
+from __future__ import annotations
+
+import os
+
+from scripts.login_test_utils import (
+    exit_with_result,
+    run_async,
+    validate_login,
+)
+
+
+def main() -> None:
+    account = os.getenv("YEEDI_ACCOUNT", "invalid@example.com")
+    country = os.getenv("YEEDI_COUNTRY", "US")
+    bad_password = os.getenv("YEEDI_BAD_PASSWORD", "not_the_real_password")
+
+    result = run_async(
+        validate_login(
+            account=account,
+            password=bad_password,
+            country=country,
+            expect_success=False,
+        )
+    )
+    exit_with_result(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/login_smoke_success.py
+++ b/scripts/login_smoke_success.py
@@ -1,0 +1,32 @@
+"""Quick smoke-test script for validating a successful Yeedi login."""
+
+from __future__ import annotations
+
+from custom_components.yeedi_c12_cloud.const import (
+    CONF_ACCOUNT,
+    CONF_COUNTRY,
+    CONF_PASSWORD,
+)
+from scripts.login_test_utils import (
+    exit_with_result,
+    load_from_env,
+    run_async,
+    validate_login,
+)
+
+
+def main() -> None:
+    creds = load_from_env()
+    result = run_async(
+        validate_login(
+            account=creds[CONF_ACCOUNT],
+            password=creds[CONF_PASSWORD],
+            country=creds[CONF_COUNTRY],
+            expect_success=True,
+        )
+    )
+    exit_with_result(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/login_test_utils.py
+++ b/scripts/login_test_utils.py
@@ -1,0 +1,112 @@
+"""Helper utilities for quick Yeedi cloud login smoke tests."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import time
+from dataclasses import dataclass
+from typing import Awaitable, Dict, List
+
+import aiohttp
+from deebot_client.api_client import ApiClient
+from deebot_client.authentication import Authenticator
+from deebot_client.util import md5
+
+from custom_components.yeedi_c12_cloud.const import (
+    CONF_ACCOUNT,
+    CONF_COUNTRY,
+    CONF_PASSWORD,
+)
+from custom_components.yeedi_c12_cloud.helpers import create_yeedi_api_config
+
+
+@dataclass(slots=True)
+class LoginResult:
+    """Container describing the outcome of an authentication attempt."""
+
+    success: bool
+    message: str
+    mqtt_devices: List[str]
+
+
+async def _perform_login(account: str, password: str, country: str) -> List[str]:
+    """Attempt to authenticate and return a list of MQTT device IDs."""
+
+    device_id = md5(str(time.time()))
+    async with aiohttp.ClientSession() as session:
+        yeedi_config = create_yeedi_api_config(
+            session,
+            device_id=device_id,
+            alpha_2_country=country,
+        )
+        auth = Authenticator(yeedi_config.rest, account, md5(password))
+        api = ApiClient(auth)
+        devices = await api.get_devices()
+
+    mqtt_devs = getattr(devices, "mqtt", []) or []
+    return [getattr(dev, "did", getattr(dev, "id", str(dev))) for dev in mqtt_devs]
+
+
+async def validate_login(
+    *,
+    account: str,
+    password: str,
+    country: str,
+    expect_success: bool,
+) -> LoginResult:
+    """Run the login routine and check the result against expectations."""
+
+    try:
+        mqtt_devices = await _perform_login(account, password, country)
+    except Exception as err:  # pragma: no cover - best effort smoke tests
+        if expect_success:
+            return LoginResult(False, f"Login failed unexpectedly: {err}", [])
+        return LoginResult(True, f"Login failed as expected: {err}", [])
+
+    if not mqtt_devices:
+        message = "Login succeeded but no MQTT devices were returned."
+        return LoginResult(expect_success and False, message, [])
+
+    if expect_success:
+        return LoginResult(True, "Login succeeded and devices discovered.", mqtt_devices)
+    return LoginResult(
+        False,
+        "Login succeeded but a failure was expected.",
+        mqtt_devices,
+    )
+
+
+def load_from_env(prefix: str = "YEEDI_") -> Dict[str, str]:
+    """Load credentials from environment variables with a prefix."""
+
+    mapping: Dict[str, str] = {
+        CONF_ACCOUNT: os.getenv(f"{prefix}ACCOUNT", ""),
+        CONF_PASSWORD: os.getenv(f"{prefix}PASSWORD", ""),
+        CONF_COUNTRY: os.getenv(f"{prefix}COUNTRY", "US"),
+    }
+    missing = [key for key, value in mapping.items() if not value and key != CONF_COUNTRY]
+    if missing:
+        joined = ", ".join(missing)
+        raise SystemExit(
+            f"Missing required environment variables for login test: {joined}."
+        )
+    return mapping
+
+
+def run_async(coro: Awaitable[LoginResult]) -> LoginResult:
+    """Convenience runner for the async helper from synchronous entry points."""
+
+    return asyncio.run(coro)
+
+
+def exit_with_result(result: LoginResult) -> None:
+    """Print a human-readable summary and exit with an appropriate code."""
+
+    print(result.message)
+    if result.mqtt_devices:
+        print("Discovered MQTT device IDs:")
+        for did in result.mqtt_devices:
+            print(f"  - {did}")
+    sys.exit(0 if result.success else 1)


### PR DESCRIPTION
## Summary
- add helper utilities and smoke test scripts for validating Yeedi cloud logins
- document the scripts in the README for easy usage
- ignore compiled Python artifacts that may be generated when running the scripts

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_68dab3a401088325973da57b3a2c0b07